### PR TITLE
Fix missing package for OpenAIResponse

### DIFF
--- a/src/main/kotlin/com/danilo/ai/storycraft/model/OpenAIResponse.kt
+++ b/src/main/kotlin/com/danilo/ai/storycraft/model/OpenAIResponse.kt
@@ -1,3 +1,5 @@
+package com.danilo.ai.storycraft.model
+
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 

--- a/src/main/kotlin/com/danilo/ai/storycraft/service/NLPService.kt
+++ b/src/main/kotlin/com/danilo/ai/storycraft/service/NLPService.kt
@@ -1,6 +1,6 @@
 package com.danilo.ai.storycraft.service
 
-import OpenAIResponse
+import com.danilo.ai.storycraft.model.OpenAIResponse
 import com.danilo.ai.storycraft.model.Message
 import com.danilo.ai.storycraft.model.OpenAIChatRequest
 import com.fasterxml.jackson.core.type.TypeReference


### PR DESCRIPTION
## Summary
- add the proper package declaration to `OpenAIResponse`
- update `NLPService` to import `OpenAIResponse` with the package

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684b21f8db608323989d699a8fc77024