### PR TITLE
Fix README Jira credentials formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The application consists of the following components:
     ```
 
 
-2**Configure Jira Credentials**:
+2. **Configure Jira Credentials**:
 
    Add your Jira token to `src/main/resources/application.yml`:
     ```yaml


### PR DESCRIPTION
## Summary
- fix README formatting for Jira setup instructions

## Testing
- `

------
https://chatgpt.com/codex/tasks/task_e_684b275ce2e48323a9dc071437639ebf